### PR TITLE
feat(useTheme): allows to configure heading levels

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -61,6 +61,16 @@ export default {
         const themeConfig = useTheme()
         themeConfig.setLocale('en') // en or es
 
+        // Optionally, you can set the heading levels to be used in content.
+        themeConfig.setHeadingLevels({
+            h1: 1,
+            h2: 3,
+            h3: 4,
+            h4: 4,
+            h5: 4,
+            h6: 4,
+        })
+
         // Use the theme.
         theme.enhanceApp({app})
     }

--- a/src/components/Common/OAHeading.vue
+++ b/src/components/Common/OAHeading.vue
@@ -1,6 +1,7 @@
 <script setup>
 import slugify from '@sindresorhus/slugify'
 import { computed, useSlots } from 'vue'
+import { useTheme } from 'vitepress-theme-openapi'
 
 const props = defineProps({
   level: {
@@ -38,11 +39,17 @@ const id = computed(() => {
 
   return slugify(value, { decamelize: false })
 })
+
+const themeConfig = useTheme()
+
+const hLevel = computed(() => {
+  return themeConfig.getHeadingLevel(props.level) ?? props.level
+})
 </script>
 
 <template>
   <component
-    :is="level"
+    :is="hLevel"
     :id="id"
     tabindex="-1"
   >

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -2,6 +2,15 @@ import { ref } from 'vue'
 import vitesseLight from 'shiki/themes/vitesse-light.mjs'
 import vitesseDark from 'shiki/themes/vitesse-dark.mjs'
 
+interface HeadingLevels {
+  h1: number
+  h2: number
+  h3: number
+  h4: number
+  h5: number
+  h6: number
+}
+
 const themeConfig = {
   locale: ref<'es' | 'en'>('en'),
   highlighterTheme: {
@@ -21,6 +30,15 @@ const jsonViewerConfig = {
 
 const schemaViewerConfig = {
   deep: ref<number>(Infinity),
+}
+
+const headingLevels: HeadingLevels = {
+  h1: 1,
+  h2: 2,
+  h3: 3,
+  h4: 4,
+  h5: 5,
+  h6: 6,
 }
 
 export function useTheme() {
@@ -68,6 +86,28 @@ export function useTheme() {
     schemaViewerConfig.deep.value = value
   }
 
+  function getHeadingLevels() {
+    return headingLevels
+  }
+
+  function getHeadingLevel(level: keyof HeadingLevels): `h${1 | 2 | 3 | 4 | 5 | 6}` {
+    const headingLevel = headingLevels[level]
+    if (headingLevel < 1 || headingLevel > 6) {
+      throw new Error(`Heading level for ${level} must be between 1 and 6.`)
+    }
+    return `h${headingLevel}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  }
+
+  function setHeadingLevels(levels: Partial<HeadingLevels>) {
+    for (const key in levels) {
+      const value = levels[key as keyof HeadingLevels]
+      if (value < 1 || value > 6) {
+        throw new Error(`Heading level for ${key} must be between 1 and 6.`)
+      }
+    }
+    Object.assign(headingLevels, levels)
+  }
+
   return {
     schemaConfig,
     getLocale,
@@ -81,5 +121,8 @@ export function useTheme() {
     setJsonViewerDeep,
     getSchemaViewerDeep,
     setSchemaViewerDeep,
+    getHeadingLevels,
+    getHeadingLevel,
+    setHeadingLevels,
   }
 }

--- a/test/composables/useTheme.test.ts
+++ b/test/composables/useTheme.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { useTheme } from './src/composables/useTheme'
+
+describe('useTheme', () => {
+  const theme = useTheme()
+
+  it('returns the default locale', () => {
+    const result = theme.getLocale()
+    expect(result).toBe('en')
+  })
+
+  it('sets and gets the locale', () => {
+    theme.setLocale('es')
+    const result = theme.getLocale()
+    expect(result).toBe('es')
+  })
+
+  it('returns the highlighter theme', () => {
+    const result = theme.getHighlighterTheme()
+    expect(result).toEqual({
+      light: expect.any(Object),
+      dark: expect.any(Object),
+    })
+  })
+
+  it('returns the default schema view', () => {
+    const result = theme.getSchemaDefaultView()
+    expect(result).toBe('contentType')
+  })
+
+  it('sets and gets the schema default view', () => {
+    theme.setSchemaDefaultView('schema')
+    const result = theme.getSchemaDefaultView()
+    expect(result).toBe('schema')
+  })
+
+  it('returns the default showBaseURL value', () => {
+    const result = theme.getShowBaseURL()
+    expect(result).toBe(false)
+  })
+
+  it('sets and gets the showBaseURL value', () => {
+    theme.setShowBaseURL(true)
+    const result = theme.getShowBaseURL()
+    expect(result).toBe(true)
+  })
+
+  it('returns the default jsonViewer deep value', () => {
+    const result = theme.getJsonViewerDeep()
+    expect(result).toBe(Infinity)
+  })
+
+  it('sets and gets the jsonViewer deep value', () => {
+    theme.setJsonViewerDeep(5)
+    const result = theme.getJsonViewerDeep()
+    expect(result).toBe(5)
+  })
+
+  it('returns the default schemaViewer deep value', () => {
+    const result = theme.getSchemaViewerDeep()
+    expect(result).toBe(Infinity)
+  })
+
+  it('sets and gets the schemaViewer deep value', () => {
+    theme.setSchemaViewerDeep(3)
+    const result = theme.getSchemaViewerDeep()
+    expect(result).toBe(3)
+  })
+
+  it('returns the heading levels', () => {
+    const result = theme.getHeadingLevels()
+    expect(result).toEqual({
+      h1: 1,
+      h2: 2,
+      h3: 3,
+      h4: 4,
+      h5: 5,
+      h6: 6,
+    })
+  })
+
+  it('returns the correct heading level', () => {
+    const result = theme.getHeadingLevel('h3')
+    expect(result).toBe('h3')
+  })
+
+  it('sets and gets the heading levels', () => {
+    theme.setHeadingLevels({ h1: 2, h2: 3 })
+    const result = theme.getHeadingLevels()
+    expect(result).toEqual({
+      h1: 2,
+      h2: 3,
+      h3: 3,
+      h4: 4,
+      h5: 5,
+      h6: 6,
+    })
+  })
+})


### PR DESCRIPTION
Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas Funciones**
	- Se han añadido opciones de configuración para niveles de encabezado personalizados en la configuración del tema (h1 a h6).
	- El componente de encabezado ahora se adapta dinámicamente a los niveles de encabezado según la configuración del tema.
- **Mejoras**
	- Mejora en la adaptabilidad del componente de encabezado a diferentes temas, permitiendo una mejor integración en la aplicación.
	- Se ha introducido una gestión estructurada de los niveles de encabezado en el sistema de gestión de temas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->