### PR TITLE
change(styles)!: use VitePress vars to better match theme

### DIFF
--- a/src/components/Schema/OASchemaBody.vue
+++ b/src/components/Schema/OASchemaBody.vue
@@ -21,7 +21,7 @@ const primitiveSchemasTypes = ['string', 'number', 'integer', 'boolean']
 
     <div
       v-else-if="props.schema?.properties"
-      class="flex flex-col pl-2 space-y-2 border-l border-gray-200 dark:border-gray-800 border-l-solid"
+      class="flex flex-col pl-2 space-y-2 border-l border-l-solid"
     >
       <OASchemaProperty
         v-for="(property, name) in props.schema.properties"
@@ -35,7 +35,7 @@ const primitiveSchemasTypes = ['string', 'number', 'integer', 'boolean']
 
     <div
       v-else-if="props.schema?.items"
-      class="flex flex-col pl-2 space-y-2 border-l border-gray-200 dark:border-gray-800 border-l-solid"
+      class="flex flex-col pl-2 space-y-2 border-l border-l-solid"
     >
       <span class="text-gray-700 dark:text-gray-300">
         array of:

--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -74,7 +74,7 @@ const lang = computed(() => {
 <template>
   <Tabs
     :default-value="schemaContentType ? themeConfig.schemaConfig.defaultView : 'schema'"
-    class="rounded border dark:border-gray-700"
+    class="rounded border"
   >
     <TabsList class="relative flex flex-row justify-start rounded-t rounded-b-none p-0">
       <TabsIndicator class="absolute left-0 h-[2px] bottom-0 w-[--radix-tabs-indicator-size] translate-x-[--radix-tabs-indicator-position] rounded-full transition-[width,transform] duration-300 bg-black dark:bg-white" />

--- a/src/components/ui/badge/index.ts
+++ b/src/components/ui/badge/index.ts
@@ -3,7 +3,7 @@ import { type VariantProps, cva } from 'class-variance-authority'
 export { default as Badge } from './Badge.vue'
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border dark:border-gray-700 px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
   {
     variants: {
       variant: {

--- a/src/json.css
+++ b/src/json.css
@@ -29,7 +29,7 @@
   @apply text-gray-500 dark:text-gray-400 !important;
 }
 .vjs-tree-node .vjs-indent-unit.has-line {
-  @apply border-gray-400 dark:border-gray-700 !important;
+  border-color: var(--vp-c-divider) !important;
 }
 .vjs-key {
   color: var(--vjs-key-color) !important;

--- a/src/style.css
+++ b/src/style.css
@@ -4,19 +4,9 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
 
-    --border: 214.3 31.8% 91.4%;
     --input: 214.3 31.8% 91.4%;
 
     --primary: 222.2 47.4% 11.2%;
@@ -37,19 +27,9 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
 
-    --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;
 
     --primary: 210 40% 98%;
@@ -65,6 +45,18 @@
     --destructive-foreground: 210 40% 98%;
 
     --ring: 212.7 26.8% 83.9%;
+  }
+}
+
+@layer components {
+  .border,
+  .border-r,
+  .border-l,
+  .border-t,
+  .border-b,
+  .border-x,
+  .border-y {
+    border-color: var(--vp-c-divider);
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,11 @@
 const animate = require('tailwindcss-animate')
+const colors = require('tailwindcss/colors')
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ['class'],
   safelist: ['dark'],
   prefix: '',
-
   content: [
     './index.html',
     './src/**/*.{vue,js,ts,jsx,tsx}',
@@ -20,11 +20,12 @@ module.exports = {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
+        gray: colors.zinc,
+        border: 'var(--vp-c-border)',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        background: '--vp-c-bg',
+        foreground: 'var(--vp-c-text-1)',
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',
@@ -38,16 +39,16 @@ module.exports = {
           foreground: 'hsl(var(--destructive-foreground))',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'var(--vp-c-bg-alt)',
+          foreground: 'var(--vp-c-text-2)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'var(--vp-c-bg-alt)',
+          foreground: 'var(--vp-c-text-1)',
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: 'var(--vp-c-bg-elv)',
+          foreground: 'var(--vp-c-text-2)',
         },
         card: {
           DEFAULT: 'hsl(var(--card))',


### PR DESCRIPTION
# Description
Changes shadcn-vue theme to re-use VitePress vars to better match style

## Related issues/external references


## Types of changes
- Style 