### PR TITLE
fix(Schema): handle circular reference and primitive values

### DIFF
--- a/dev/.vitepress/config.ts
+++ b/dev/.vitepress/config.ts
@@ -56,6 +56,10 @@ export default defineConfigWithTheme({
             text: 'Response Statuses',
             link: '/response-statuses',
           },
+          {
+            text: 'Schemas',
+            link: '/schemas',
+          },
         ],
       },
     ],

--- a/dev/schemas/index.md
+++ b/dev/schemas/index.md
@@ -1,0 +1,14 @@
+---
+aside: false
+outline: false
+title: vitepress-theme-openapi
+---
+
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import spec from '../../docs/public/openapi-schemas.json'
+
+const { isDark } = useData()
+</script>
+
+<OASpec :spec="spec" :isDark="isDark" />

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -88,6 +88,10 @@ export default defineConfigWithTheme({
                 text: 'Response Statuses',
                 link: '/example/response-statuses',
               },
+              {
+                text: 'Schemas',
+                link: '/example/schemas',
+              },
             ],
           },
         ],

--- a/docs/example/schemas/index.md
+++ b/docs/example/schemas/index.md
@@ -1,0 +1,14 @@
+---
+aside: false
+outline: false
+title: vitepress-theme-openapi
+---
+
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import spec from '../../public/openapi-schemas.json'
+
+const { isDark } = useData()
+</script>
+
+<OASpec :spec="spec" :isDark="isDark" />

--- a/docs/public/openapi-schemas.json
+++ b/docs/public/openapi-schemas.json
@@ -1,0 +1,293 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example of an OpenAPI document different schemas",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/circular-reference": {
+      "get": {
+        "summary": "Get a parent",
+        "operationId": "getCircularReference",
+        "description": "Example of a JSON object with a circular reference.",
+        "responses": {
+          "200": {
+            "description": "A parent with a child",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Parent"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/multiple-levels": {
+      "get": {
+        "summary": "Get the root object",
+        "operationId": "getMultipleLevels",
+        "description": "Example of a JSON object with multiple levels.",
+        "responses": {
+          "200": {
+            "description": "Example of a deeply nested structure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Level1"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Parent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "child": {
+            "$ref": "#/components/schemas/Child"
+          }
+        }
+      },
+      "Child": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "parent": {
+            "$ref": "#/components/schemas/Parent"
+          }
+        }
+      },
+      "Level1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level2": {
+            "$ref": "#/components/schemas/Level2"
+          }
+        }
+      },
+      "Level2": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level3": {
+            "$ref": "#/components/schemas/Level3"
+          }
+        }
+      },
+      "Level3": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level4": {
+            "$ref": "#/components/schemas/Level4"
+          }
+        }
+      },
+      "Level4": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level5": {
+            "$ref": "#/components/schemas/Level5"
+          }
+        }
+      },
+      "Level5": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level6": {
+            "$ref": "#/components/schemas/Level6"
+          }
+        }
+      },
+      "Level6": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level7": {
+            "$ref": "#/components/schemas/Level7"
+          }
+        }
+      },
+      "Level7": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level8": {
+            "$ref": "#/components/schemas/Level8"
+          }
+        }
+      },
+      "Level8": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level9": {
+            "$ref": "#/components/schemas/Level9"
+          }
+        }
+      },
+      "Level9": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level10": {
+            "$ref": "#/components/schemas/Level10"
+          }
+        }
+      },
+      "Level10": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level11": {
+            "$ref": "#/components/schemas/Level11"
+          }
+        }
+      },
+      "Level11": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level12": {
+            "$ref": "#/components/schemas/Level12"
+          }
+        }
+      },
+      "Level12": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level13": {
+            "$ref": "#/components/schemas/Level13"
+          }
+        }
+      },
+      "Level13": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level14": {
+            "$ref": "#/components/schemas/Level14"
+          }
+        }
+      },
+      "Level14": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level15": {
+            "$ref": "#/components/schemas/Level15"
+          }
+        }
+      },
+      "Level15": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level16": {
+            "$ref": "#/components/schemas/Level16"
+          }
+        }
+      },
+      "Level16": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level17": {
+            "$ref": "#/components/schemas/Level17"
+          }
+        }
+      },
+      "Level17": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level18": {
+            "$ref": "#/components/schemas/Level18"
+          }
+        }
+      },
+      "Level18": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level19": {
+            "$ref": "#/components/schemas/Level19"
+          }
+        }
+      },
+      "Level19": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "level20": {
+            "$ref": "#/components/schemas/Level20"
+          }
+        }
+      },
+      "Level20": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "finalValue": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/public/openapi-schemas.json
+++ b/docs/public/openapi-schemas.json
@@ -42,6 +42,66 @@
           }
         }
       }
+    },
+    "/primitive-string": {
+      "get": {
+        "summary": "Get a string",
+        "operationId": "getPrimitiveString",
+        "description": "Example of a JSON object with a string.",
+        "responses": {
+          "200": {
+            "description": "A string",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "example": "Hello, World!"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/primitive-number": {
+      "get": {
+        "summary": "Get a number",
+        "operationId": "getPrimitiveNumber",
+        "description": "Example of a JSON object with a number.",
+        "responses": {
+          "200": {
+            "description": "A number",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "number",
+                  "example": 42
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/primitive-boolean": {
+      "get": {
+        "summary": "Get a boolean",
+        "operationId": "getPrimitiveBoolean",
+        "description": "Example of a JSON object with a boolean.",
+        "responses": {
+          "200": {
+            "description": "A boolean",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/src/components/Common/OACodeBlock.vue
+++ b/src/components/Common/OACodeBlock.vue
@@ -8,7 +8,7 @@ import { destr } from 'destr'
 
 const props = defineProps({
   code: {
-    type: [String, Object, Array],
+    type: [String, Object, Array, Number, Boolean],
     required: true,
   },
   lang: {

--- a/src/components/Schema/OASchemaBody.vue
+++ b/src/components/Schema/OASchemaBody.vue
@@ -8,14 +8,31 @@ const props = defineProps({
     type: Number,
     default: Infinity,
   },
+  visited: {
+    type: Set,
+    default: () => new Set(),
+  },
+  level: {
+    type: Number,
+    default: 0,
+  },
 })
 
 const primitiveSchemasTypes = ['string', 'number', 'integer', 'boolean']
+const isCircularRef = props.visited.has(props.schema) && props.level > 10
+
+if (!isCircularRef) {
+  props.visited.add(props.schema)
+}
 </script>
 
 <template>
   <div class="flex flex-col">
-    <div v-if="primitiveSchemasTypes.includes(props.schema.type)">
+    <div v-if="isCircularRef">
+      <span class="text-gray-700 dark:text-gray-300">[Circular Reference]</span>
+    </div>
+
+    <div v-else-if="primitiveSchemasTypes.includes(props.schema.type)">
       <OASchemaPrimitiveProperty :property="props.schema" />
     </div>
 
@@ -30,6 +47,8 @@ const primitiveSchemasTypes = ['string', 'number', 'integer', 'boolean']
         :name="name"
         :schema="props.schema"
         :deep="props.deep - 1"
+        :visited="new Set(visited)"
+        :level="level + 1"
       />
     </div>
 
@@ -44,6 +63,8 @@ const primitiveSchemasTypes = ['string', 'number', 'integer', 'boolean']
       <OASchemaBody
         :schema="props.schema.items"
         :deep="props.deep - 1"
+        :visited="new Set(visited)"
+        :level="level + 1"
       />
     </div>
   </div>

--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -73,7 +73,7 @@ const lang = computed(() => {
 
 <template>
   <Tabs
-    :default-value="schemaContentType ? themeConfig.schemaConfig.defaultView : 'schema'"
+    :default-value="schemaContentType !== null ? themeConfig.schemaConfig.defaultView : 'schema'"
     class="rounded border"
   >
     <TabsList class="relative flex flex-row justify-start rounded-t rounded-b-none p-0">
@@ -85,7 +85,7 @@ const lang = computed(() => {
         {{ $t('Schema') }}
       </TabsTrigger>
       <TabsTrigger
-        v-if="schemaContentType"
+        v-if="schemaContentType !== null"
         value="contentType"
         class="h-full"
       >
@@ -126,7 +126,7 @@ const lang = computed(() => {
         </div>
 
         <OACodeBlock
-          v-if="schemaContentType"
+          v-if="schemaContentType !== null"
           :code="schemaContentType"
           :lang="lang"
           :label="contentTypeLabel"

--- a/src/components/Schema/OASchemaTabs.vue
+++ b/src/components/Schema/OASchemaTabs.vue
@@ -69,11 +69,13 @@ const lang = computed(() => {
   }
   return props.contentType
 })
+
+const hasSchemaContentType = computed(() => schemaContentType.value !== null)
 </script>
 
 <template>
   <Tabs
-    :default-value="schemaContentType !== null ? themeConfig.schemaConfig.defaultView : 'schema'"
+    :default-value="hasSchemaContentType ? themeConfig.schemaConfig.defaultView : 'schema'"
     class="rounded border"
   >
     <TabsList class="relative flex flex-row justify-start rounded-t rounded-b-none p-0">
@@ -85,7 +87,7 @@ const lang = computed(() => {
         {{ $t('Schema') }}
       </TabsTrigger>
       <TabsTrigger
-        v-if="schemaContentType !== null"
+        v-if="hasSchemaContentType"
         value="contentType"
         class="h-full"
       >
@@ -126,7 +128,7 @@ const lang = computed(() => {
         </div>
 
         <OACodeBlock
-          v-if="schemaContentType !== null"
+          v-if="hasSchemaContentType"
           :code="schemaContentType"
           :lang="lang"
           :label="contentTypeLabel"

--- a/src/lib/generateSchemaJson.ts
+++ b/src/lib/generateSchemaJson.ts
@@ -1,7 +1,17 @@
 import { formatJson } from './formatJson'
 
 export function generateSchemaJson(schema: any, useExample = false) {
-  return formatJson(propertiesTypesJsonRecursive(schema, useExample, new Set()))
+  if (schema === null || schema === undefined) {
+    return '{}'
+  }
+
+  const properties = propertiesTypesJsonRecursive(schema, useExample, new Set())
+
+  if (typeof properties === 'string' || typeof properties === 'number' || typeof properties === 'boolean') {
+    return properties
+  }
+
+  return formatJson(properties)
 }
 
 export function propertiesTypesJsonRecursive(schema: any, useExample = false, visited = new Set(), level = 0) {
@@ -19,7 +29,7 @@ export function propertiesTypesJsonRecursive(schema: any, useExample = false, vi
   }
 
   if (!schema?.properties) {
-    return schema
+    return getPropertyValue(schema, useExample, new Set(visited), level)
   }
 
   const propertiesKeys = Object.keys(schema.properties)
@@ -56,7 +66,7 @@ function getPropertyValue(property: any, useExample: boolean, visited: Set<any>,
       return []
     case 'object':
       if (property.properties) {
-        return propertiesTypesJsonRecursive(property, useExample, visited, level + 1)
+        return propertiesTypesJsonRecursive(property, useExample, new Set(visited), level + 1)
       }
       return {}
     default:

--- a/src/lib/hasExample.ts
+++ b/src/lib/hasExample.ts
@@ -1,14 +1,26 @@
-export function hasExample(schema: any): boolean {
+export function hasExample(schema: any, visited: Set<any> = new Set(), level: number = 0): boolean {
+  if (visited.has(schema)) {
+    if (level > 10) {
+      return false // Assume no example for circular references.
+    }
+
+    visited = new Set()
+  }
+
+  visited.add(schema)
+
   if (schema?.example) {
     return true
   }
 
   if (schema?.properties) {
-    return Object.values(schema.properties).some(property => hasExample(property))
+    return Object.values(schema.properties).some(property =>
+      hasExample(property, new Set(visited), level + 1),
+    )
   }
 
   if (schema?.items) {
-    return hasExample(schema.items)
+    return hasExample(schema.items, new Set(visited), level + 1)
   }
 
   return false

--- a/test/lib/generateSchemaJson.test.ts
+++ b/test/lib/generateSchemaJson.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { merge } from 'allof-merge'
+import { dereferenceSync } from '@trojs/openapi-dereference'
 import { generateSchemaJson } from '../../src/lib/generateSchemaJson'
+import { specWithCircularRef, specWithMultipleLevels } from '../testsConstants'
+import { formatJson } from '../../src/lib/formatJson'
 
 describe('generateSchemaJson', () => {
   it('generates JSON for schema with string property', () => {
@@ -172,5 +175,103 @@ describe('generateSchemaJson', () => {
       name: 'string',
       id: 0,
     }, null, 2))
+  })
+})
+
+describe('schema with circular references', () => {
+  it('generates JSON for schema with circular references', () => {
+    const schema = dereferenceSync(merge(specWithCircularRef)).components.schemas.Parent
+    const result = generateSchemaJson(schema)
+    expect(result).toBe(
+      formatJson({
+        id: 'string',
+        child: {
+          id: 'string',
+          parent: {
+            id: 'string',
+            child: {
+              id: 'string',
+              parent: {
+                id: 'string',
+                child: {
+                  id: 'string',
+                  parent: '[Circular Reference]',
+                },
+              },
+            },
+          },
+        },
+      }),
+    )
+  })
+})
+
+describe('schema with multiple levels', () => {
+  it('generates JSON for schema with circular references', () => {
+    const schema = dereferenceSync(merge(specWithMultipleLevels)).components.schemas.Level1
+    const result = generateSchemaJson(schema)
+    expect(result).toBe(
+      formatJson({
+        id: 'string',
+        level2: {
+          id: 'string',
+          level3: {
+            id: 'string',
+            level4: {
+              id: 'string',
+              level5: {
+                id: 'string',
+                level6: {
+                  id: 'string',
+                  level7: {
+                    id: 'string',
+                    level8: {
+                      id: 'string',
+                      level9: {
+                        id: 'string',
+                        level10: {
+                          id: 'string',
+                          level11: {
+                            id: 'string',
+                            level12: {
+                              id: 'string',
+                              level13: {
+                                id: 'string',
+                                level14: {
+                                  id: 'string',
+                                  level15: {
+                                    id: 'string',
+                                    level16: {
+                                      id: 'string',
+                                      level17: {
+                                        id: 'string',
+                                        level18: {
+                                          id: 'string',
+                                          level19: {
+                                            id: 'string',
+                                            level20: {
+                                              id: 'string',
+                                              finalValue: 'string',
+                                            },
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    )
   })
 })

--- a/test/lib/generateSchemaJson.test.ts
+++ b/test/lib/generateSchemaJson.test.ts
@@ -176,6 +176,30 @@ describe('generateSchemaJson', () => {
       id: 0,
     }, null, 2))
   })
+
+  it('generates JSON for primitive string schema', () => {
+    const schema = {
+      type: 'string',
+    }
+    const result = generateSchemaJson(schema)
+    expect(result).toBe('string')
+  })
+
+  it('generates JSON for primitive number schema', () => {
+    const schema = {
+      type: 'number',
+    }
+    const result = generateSchemaJson(schema)
+    expect(result).toBe(0)
+  })
+
+  it('generates JSON for primitive boolean schema', () => {
+    const schema = {
+      type: 'boolean',
+    }
+    const result = generateSchemaJson(schema)
+    expect(result).toBe(true)
+  })
 })
 
 describe('schema with circular references', () => {

--- a/test/lib/hasExample.test.ts
+++ b/test/lib/hasExample.test.ts
@@ -1,20 +1,23 @@
-import { describe, it, expect } from 'vitest';
-import { hasExample } from "../../src/lib/hasExample";
+import { describe, expect, it } from 'vitest'
+import { dereferenceSync } from '@trojs/openapi-dereference'
+import { merge } from 'allof-merge'
+import { hasExample } from '../../src/lib/hasExample'
+import { specWithCircularRef, specWithCircularRefAndExample } from '../testsConstants'
 
 describe('hasExample', () => {
   it('returns true if schema has an example at the root level', () => {
-    const schema = { example: 'exampleValue' };
-    expect(hasExample(schema)).toBe(true);
-  });
+    const schema = { example: 'exampleValue' }
+    expect(hasExample(schema)).toBe(true)
+  })
 
   it('returns true if schema has an example in properties', () => {
     const schema = {
       properties: {
         prop1: { example: 'exampleValue' },
       },
-    };
-    expect(hasExample(schema)).toBe(true);
-  });
+    }
+    expect(hasExample(schema)).toBe(true)
+  })
 
   it('returns true if schema has an example in nested properties', () => {
     const schema = {
@@ -25,47 +28,62 @@ describe('hasExample', () => {
           },
         },
       },
-    };
-    expect(hasExample(schema)).toBe(true);
-  });
+    }
+    expect(hasExample(schema)).toBe(true)
+  })
 
   it('returns true if schema has an example in items', () => {
     const schema = {
       items: { example: 'exampleValue' },
-    };
-    expect(hasExample(schema)).toBe(true);
-  });
+    }
+    expect(hasExample(schema)).toBe(true)
+  })
 
   it('returns true if schema has an example in nested items', () => {
     const schema = {
       items: {
         items: { example: 'exampleValue' },
       },
-    };
-    expect(hasExample(schema)).toBe(true);
-  });
+    }
+    expect(hasExample(schema)).toBe(true)
+  })
 
   it('returns false if schema has no example', () => {
     const schema = {
       properties: {
         prop1: {},
       },
-    };
-    expect(hasExample(schema)).toBe(false);
-  });
+    }
+    expect(hasExample(schema)).toBe(false)
+  })
 
   it('returns false if schema is empty', () => {
-    const schema = {};
-    expect(hasExample(schema)).toBe(false);
-  });
+    const schema = {}
+    expect(hasExample(schema)).toBe(false)
+  })
 
   it('returns false if schema is null', () => {
-    const schema = null;
-    expect(hasExample(schema)).toBe(false);
-  });
+    const schema = null
+    expect(hasExample(schema)).toBe(false)
+  })
 
   it('returns false if schema is undefined', () => {
-      const schema = undefined;
-      expect(hasExample(schema)).toBe(false);
-    });
-});
+    const schema = undefined
+    expect(hasExample(schema)).toBe(false)
+  })
+})
+
+describe('schema with circular references', () => {
+  it('returns false if schema with circular references has no example', () => {
+    const schema = dereferenceSync(merge(specWithCircularRef)).components.schemas.Parent
+    const result = hasExample(schema)
+    expect(result).toBe(false)
+  })
+
+  it('returns true if schema with circular references has an example', () => {
+    const schema = dereferenceSync(merge(specWithCircularRefAndExample)).components.schemas.Parent
+    schema.example = 'exampleValue'
+    const result = hasExample(schema)
+    expect(result).toBe(true)
+  })
+})

--- a/test/testsConstants.ts
+++ b/test/testsConstants.ts
@@ -106,3 +106,376 @@ export const spec = {
     },
   },
 }
+
+export const specWithCircularRef = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Minimal API with Circular Reference',
+    version: '1.0.0',
+  },
+  paths: {
+    '/parent': {
+      get: {
+        summary: 'Get a parent',
+        operationId: 'getParent',
+        responses: {
+          200: {
+            description: 'A parent with a child',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Parent',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Parent: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          child: {
+            $ref: '#/components/schemas/Child',
+          },
+        },
+      },
+      Child: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          parent: {
+            $ref: '#/components/schemas/Parent',
+          },
+        },
+      },
+    },
+  },
+}
+
+export const specWithCircularRefAndExample = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Minimal API with Circular Reference and Example',
+    version: '1.0.0',
+  },
+  paths: {
+    '/parent': {
+      get: {
+        summary: 'Get a parent',
+        operationId: 'getParent',
+        responses: {
+          200: {
+            description: 'A parent with a child',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Parent',
+                },
+                example: {
+                  id: '1',
+                  child: {
+                    id: '2',
+                    parent: {
+                      id: '1',
+                      child: {
+                        id: '2',
+                        parent: '[Circular Reference]',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Parent: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          child: {
+            $ref: '#/components/schemas/Child',
+          },
+        },
+      },
+      Child: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          parent: {
+            $ref: '#/components/schemas/Parent',
+          },
+        },
+      },
+    },
+  },
+}
+
+export const specWithMultipleLevels = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Deep Nested API without Circular Reference',
+    version: '1.0.0',
+  },
+  paths: {
+    '/root': {
+      get: {
+        summary: 'Get the root object',
+        operationId: 'getRoot',
+        responses: {
+          200: {
+            description: 'A deeply nested structure',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Level1',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Level1: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level2: {
+            $ref: '#/components/schemas/Level2',
+          },
+        },
+      },
+      Level2: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level3: {
+            $ref: '#/components/schemas/Level3',
+          },
+        },
+      },
+      Level3: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level4: {
+            $ref: '#/components/schemas/Level4',
+          },
+        },
+      },
+      Level4: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level5: {
+            $ref: '#/components/schemas/Level5',
+          },
+        },
+      },
+      Level5: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level6: {
+            $ref: '#/components/schemas/Level6',
+          },
+        },
+      },
+      Level6: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level7: {
+            $ref: '#/components/schemas/Level7',
+          },
+        },
+      },
+      Level7: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level8: {
+            $ref: '#/components/schemas/Level8',
+          },
+        },
+      },
+      Level8: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level9: {
+            $ref: '#/components/schemas/Level9',
+          },
+        },
+      },
+      Level9: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level10: {
+            $ref: '#/components/schemas/Level10',
+          },
+        },
+      },
+      Level10: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level11: {
+            $ref: '#/components/schemas/Level11',
+          },
+        },
+      },
+      Level11: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level12: {
+            $ref: '#/components/schemas/Level12',
+          },
+        },
+      },
+      Level12: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level13: {
+            $ref: '#/components/schemas/Level13',
+          },
+        },
+      },
+      Level13: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level14: {
+            $ref: '#/components/schemas/Level14',
+          },
+        },
+      },
+      Level14: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level15: {
+            $ref: '#/components/schemas/Level15',
+          },
+        },
+      },
+      Level15: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level16: {
+            $ref: '#/components/schemas/Level16',
+          },
+        },
+      },
+      Level16: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level17: {
+            $ref: '#/components/schemas/Level17',
+          },
+        },
+      },
+      Level17: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level18: {
+            $ref: '#/components/schemas/Level18',
+          },
+        },
+      },
+      Level18: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level19: {
+            $ref: '#/components/schemas/Level19',
+          },
+        },
+      },
+      Level19: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          level20: {
+            $ref: '#/components/schemas/Level20',
+          },
+        },
+      },
+      Level20: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+          },
+          finalValue: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
# Description
Allows to handle schema with circular references.

It handles up to 10 levels, inspired by Scalar (https://sandbox.scalar.com/e/o6jBR). It could be configured via `useTheme` composable in the future if needed.

Scalar:
![image](https://github.com/user-attachments/assets/ad3fd0b8-8162-47c1-b629-932b4a6ec26b)

VitePress Theme OpenAPI:
![image](https://github.com/user-attachments/assets/b6494ecc-328a-4091-985b-49e15e2344dd)


## Related issues/external references
Fixes #57 

## Types of changes
- Bug fix
