### PR TITLE
feat(playground): allows to save tokens via localStorage

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,6 +58,10 @@ export default defineConfigWithTheme({
                 text: 'useTheme',
                 link: '/composables/useTheme',
               },
+              {
+                text: 'usePlayground',
+                link: '/composables/usePlayground',
+              },
             ],
           },
         ],

--- a/docs/composables/usePlayground.md
+++ b/docs/composables/usePlayground.md
@@ -1,0 +1,28 @@
+# `usePlayground` Composable
+
+The `usePlayground` composable provides functions to manage the Playground.
+
+You can use the `usePlayground` composable to configure the Playground in your `.vitepress/theme/index.js` file, or in any `.md` page/file.
+
+```ts
+import { usePlayground } from 'vitepress-theme-openapi'
+
+export default {
+    async enhanceApp({ app, router, siteData }) {
+        const playground = usePlayground()
+        
+        // Set custom security scheme default values.
+        playground.setSecuritySchemeDefaultValues({
+            'http-basic': 'Custom Basic Auth',
+            'http-bearer': 'Custom Bearer Token',
+            // ...
+        })
+    }
+}
+```
+
+## Security Scheme Default Values Configuration
+
+| Function                         | Description                                      | Default Value                                                                                                                                 | Allowed Values                         |
+|----------------------------------|--------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| `setSecuritySchemeDefaultValues` | Sets custom default values for security schemes. | `{ 'http-basic': 'Basic Auth', 'http-bearer': 'Bearer Token', 'apiKey': null, 'openIdConnect': 'OpenID Connect', 'oauth2': 'OAuth2 Token', }` | Partial\<SecuritySchemeDefaultValues\> |

--- a/src/components/Try/OARequestSecurityInput.vue
+++ b/src/components/Try/OARequestSecurityInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, defineEmits, defineProps } from 'vue'
+import { usePlayground } from 'vitepress-theme-openapi'
 import { Input } from 'vitepress-theme-openapi/components/ui/input'
 
 const props = defineProps({
@@ -18,18 +19,11 @@ const emits = defineEmits([
 ])
 
 const placeholder = computed(() => {
-  switch (props.scheme.type) {
-    case 'http':
-      return props.scheme.scheme === 'basic' ? 'Basic Auth' : 'Bearer Token'
-    case 'apiKey':
-      return props.scheme.name
-    case 'openIdConnect':
-      return 'OpenID Connect'
-    case 'oauth2':
-      return 'OAuth2 Token'
-    default:
-      return ''
+  if (props.modelValue) {
+    return props.modelValue
   }
+
+  return usePlayground().getSecuritySchemeDefaultValue(props.scheme)
 })
 </script>
 

--- a/src/composables/usePlayground.ts
+++ b/src/composables/usePlayground.ts
@@ -1,0 +1,41 @@
+interface SecuritySchemeDefaultValues {
+  'http-basic': string
+  'http-bearer': string
+  'apiKey': string | null
+  'openIdConnect': string
+  'oauth2': string
+}
+
+let securitySchemeDefaultValues: SecuritySchemeDefaultValues = {
+  'http-basic': 'Basic Auth',
+  'http-bearer': 'Bearer Token',
+  'apiKey': null,
+  'openIdConnect': 'OpenID Connect',
+  'oauth2': 'OAuth2 Token',
+}
+
+export function usePlayground() {
+  function setSecuritySchemeDefaultValues(values: Partial<SecuritySchemeDefaultValues>) {
+    securitySchemeDefaultValues = {
+      ...securitySchemeDefaultValues,
+      ...values,
+    }
+  }
+
+  function getSecuritySchemeDefaultValue(scheme) {
+    if (scheme.type === 'http') {
+      return securitySchemeDefaultValues[`http-${scheme.scheme}`]
+    }
+
+    if (Object.keys(securitySchemeDefaultValues).includes(scheme.type)) {
+      return securitySchemeDefaultValues[scheme.type] ?? scheme.name
+    }
+
+    return scheme.name ?? ''
+  }
+
+  return {
+    setSecuritySchemeDefaultValues,
+    getSecuritySchemeDefaultValue,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export { useSidebar } from './composables/useSidebar'
 export { useOpenapi } from './composables/useOpenapi'
 export { useTheme } from './composables/useTheme'
 export { useShiki } from './composables/useShiki'
+export { usePlayground } from './composables/usePlayground'
 export { OpenApi } from './lib/OpenApi'
 
 interface VPTheme {

--- a/test/composables/usePlayground.test.ts
+++ b/test/composables/usePlayground.test.ts
@@ -84,4 +84,11 @@ describe('securityScheme default values with custom values', () => {
     playground.setSecuritySchemeDefaultValues({ unknownType: 'Custom Scheme' })
     expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Scheme')
   })
+
+  it('does not overwrite existing custom values when called with an empty object', () => {
+    const scheme = { type: 'http', scheme: 'basic' }
+    playground.setSecuritySchemeDefaultValues({ 'http-basic': 'Custom Basic Auth' })
+    playground.setSecuritySchemeDefaultValues({})
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Basic Auth')
+  })
 })

--- a/test/composables/usePlayground.test.ts
+++ b/test/composables/usePlayground.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { usePlayground } from './src/composables/usePlayground'
+
+describe('securityScheme default values', () => {
+  const playground = usePlayground()
+
+  it('returns "Basic Auth" for http-basic scheme', () => {
+    const scheme = { type: 'http', scheme: 'basic' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Basic Auth')
+  })
+
+  it('returns "Bearer Token" for http-bearer scheme', () => {
+    const scheme = { type: 'http', scheme: 'bearer' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Bearer Token')
+  })
+
+  it('returns "OpenID Connect" for openIdConnect scheme', () => {
+    const scheme = { type: 'openIdConnect' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('OpenID Connect')
+  })
+
+  it('returns "OAuth2 Token" for oauth2 scheme', () => {
+    const scheme = { type: 'oauth2' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('OAuth2 Token')
+  })
+
+  it('returns scheme name for apiKey scheme', () => {
+    const scheme = { type: 'apiKey', name: 'Custom API Key' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom API Key')
+  })
+
+  it('returns scheme name if type is not in securitySchemeDefaultValues', () => {
+    const scheme = { type: 'customType', name: 'Custom Scheme' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Scheme')
+  })
+
+  it('returns empty string if type is not in securitySchemeDefaultValues and name is not provided', () => {
+    const scheme = { type: 'unknownType' }
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('')
+  })
+})
+
+describe('securityScheme default values with custom values', () => {
+  const playground = usePlayground()
+
+  it('returns custom value for http-basic scheme', () => {
+    const scheme = { type: 'http', scheme: 'basic' }
+    playground.setSecuritySchemeDefaultValues({ 'http-basic': 'Custom Basic Auth' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Basic Auth')
+  })
+
+  it('returns custom value for http-bearer scheme', () => {
+    const scheme = { type: 'http', scheme: 'bearer' }
+    playground.setSecuritySchemeDefaultValues({ 'http-bearer': 'Custom Bearer Token' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Bearer Token')
+  })
+
+  it('returns custom value for openIdConnect scheme', () => {
+    const scheme = { type: 'openIdConnect' }
+    playground.setSecuritySchemeDefaultValues({ openIdConnect: 'Custom OpenID Connect' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom OpenID Connect')
+  })
+
+  it('returns custom value for oauth2 scheme', () => {
+    const scheme = { type: 'oauth2' }
+    playground.setSecuritySchemeDefaultValues({ oauth2: 'Custom OAuth2 Token' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom OAuth2 Token')
+  })
+
+  it('returns custom value for apiKey scheme', () => {
+    const scheme = { type: 'apiKey', name: 'Custom API Key' }
+    playground.setSecuritySchemeDefaultValues({ apiKey: 'MyAPIKey' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('MyAPIKey')
+  })
+
+  it('returns custom value for unknown scheme type', () => {
+    const scheme = { type: 'customType', name: 'Custom Scheme' }
+    playground.setSecuritySchemeDefaultValues({ customType: 'Custom Scheme' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Scheme')
+  })
+
+  it('returns custom value for unknown scheme type without name', () => {
+    const scheme = { type: 'unknownType' }
+    playground.setSecuritySchemeDefaultValues({ unknownType: 'Custom Scheme' })
+    expect(playground.getSecuritySchemeDefaultValue(scheme)).toBe('Custom Scheme')
+  })
+})


### PR DESCRIPTION
# Description

- Allows to save Auth Tokens via LocalStorage and share across operations.
- Adds a `usePlayground` composable, to allows to customize Security Scheme default values (and other things in the future).

## Related issues/external references

Closes #59 

## Types of changes

- New feature
