### PR TITLE
feat(operations): allows to specify Path's Servers

### DIFF
--- a/src/components/Path/OAPath.vue
+++ b/src/components/Path/OAPath.vue
@@ -24,7 +24,7 @@ const operationPath = openapi.getOperationPath(props.id)
 
 const operationMethod = openapi.getOperationMethod(props.id)?.toUpperCase()
 
-const baseUrl = openapi.getBaseUrl()
+const baseUrl = openapi.getBaseUrl(props.id)
 
 const securitySchemes = openapi.getSecuritySchemes(props.id)
 

--- a/src/lib/OpenApi.ts
+++ b/src/lib/OpenApi.ts
@@ -45,7 +45,23 @@ export function OpenApi({ spec }: { spec: any } = { spec: null }) {
     return parsedSpec
   }
 
-  function getBaseUrl() {
+  function getBaseUrl(operationId?: string) {
+    if (operationId) {
+      const operationPath = getOperationPath(operationId)
+      if (operationPath) {
+        const pathServers = spec.paths[operationPath]?.servers
+        if (pathServers && pathServers.length > 0) {
+          try {
+            const firstUrl = pathServers[0].url
+            new URL(firstUrl)
+            return firstUrl
+          } catch {
+            console.warn('Invalid server URL in path servers:', pathServers)
+          }
+        }
+      }
+    }
+
     if (!spec?.servers || spec.servers.length === 0) {
       return DEFAULT_SERVER_URL
     }

--- a/test/composables/openapi.test.ts
+++ b/test/composables/openapi.test.ts
@@ -72,3 +72,48 @@ describe('openapi with spec', () => {
     expect(result).toEqual(spec.servers)
   })
 })
+
+describe('spec with different servers for specific path', () => {
+  const spec = {
+    openapi: '3.0.0',
+    servers: [
+      {
+        url: 'https://api.example.com',
+      },
+    ],
+    paths: {
+      '/use-global-server': {
+        get: {
+          operationId: 'useGlobalServer',
+        },
+      },
+      '/use-local-server': {
+        get: {
+          operationId: 'useLocalServer',
+        },
+        servers: [
+          {
+            url: 'https://api.local.com',
+          },
+        ],
+      },
+    },
+  }
+
+  const openapi = OpenApi({ spec })
+
+  it('returns global server for getBaseUrl', () => {
+    const result = openapi.getBaseUrl()
+    expect(result).toBe('https://api.example.com')
+  })
+
+  it('returns global server for useGlobalServer', () => {
+    const result = openapi.getBaseUrl('useGlobalServer')
+    expect(result).toBe('https://api.example.com')
+  })
+
+  it('returns local server for useLocalServer', () => {
+    const result = openapi.getBaseUrl('useLocalServer')
+    expect(result).toBe('https://api.local.com')
+  })
+})


### PR DESCRIPTION
# Description

Allows to specify custom Servers for specific Paths.

## Related issues/external references

- https://spec.openapis.org/oas/latest.html#paths-object

## Types of changes

- New feature
