### PR TITLE
chore(bug issues template): reproduction

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -16,8 +16,14 @@ body:
       label: Desired behavior
       description: A clear description of what you think should happen.
       placeholder: In this situation, I expected ...
-  - type: textarea
+  - type: input
     id: reproduction
+    attributes:
+      label: Reproduction
+      description: Please provide a link via [vitepress-theme-openapi-starter StackBlitz](https://stackblitz.com/fork/github/enzonotario/vitepress-theme-openapi-starter?file=public/openapi.json) or a link to a repo that can reproduce the problem you ran into. A [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example) is required ([Why?](https://antfu.me/posts/why-reproductions-are-required)). If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label.
+      placeholder: Reproduction URL
+  - type: textarea
+    id: reproduction-steps
     attributes:
       label: Steps to reproduce
       description: Clearly describe the steps or actions taken to arrive at the problem. Include any relevant code snippets or configuration details.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

# Description

Change `reproduction` to `reproduction-steps` field. And adds `reproduction` field for URLs to repository/link reproduction.

## Related issues/external references


## Types of changes

- CI/CD
